### PR TITLE
Improved determination of indexes path

### DIFF
--- a/src/NHibernate.Search.Tests/NHibernate.Search.Tests.csproj
+++ b/src/NHibernate.Search.Tests/NHibernate.Search.Tests.csproj
@@ -55,27 +55,27 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
+      <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
+      <HintPath>..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
+      <HintPath>..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NHibernate.Search.Tests/Util/DirectoryHelperTest.cs
+++ b/src/NHibernate.Search.Tests/Util/DirectoryHelperTest.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
-
-namespace NHibernate.Search.Tests.Util
+﻿namespace NHibernate.Search.Tests.Util
 {
+    using System;
+    using System.Collections.Generic;
     using System.IO;
-    using System.Threading;
-
+    using System.Linq;
+    using System.Threading;    
     using NUnit.Framework;
 
     [TestFixture]
@@ -53,6 +53,22 @@ namespace NHibernate.Search.Tests.Util
 
             DirectoryInfo info = new DirectoryInfo(root + "/Fred");
             Assert.IsTrue(info.Exists);
+        }
+
+        [Test]
+        public void CreateViaParent()
+        {
+            var properties = new Dictionary<string, string>();
+            properties["indexBase"] = "../Wilma";
+            properties["indexName"] = "fakeIndex";
+
+            DirectoryInfo info = DirectoryProviderHelper.DetermineIndexDir(null, properties);
+
+            // get process execution path
+            DirectoryInfo targetParentDir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+
+            // check if a directory info object was returned and "Wilma" folder was created into parent folder of execution process
+            Assert.IsTrue(targetParentDir.Parent.GetDirectories().Any(d => d.Name.Equals(info.Parent.Name)));
         }
 
         #region Helper methods

--- a/src/NHibernate.Search/NHibernate.Search.csproj
+++ b/src/NHibernate.Search/NHibernate.Search.csproj
@@ -62,19 +62,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
+      <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
+      <HintPath>..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
+      <HintPath>..\packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
Added support to parent path syntax in indexBase path (eg. "../indexes").
This is usefull when indexes are located out or in a parent folder of application/website execution folder and we don't want or wish to use absolute path, specially when deploying on differents enviroments.

Same fix  was merged today in https://github.com/nhibernate/NHibernate-Search, but I do a pull request also on your branch because of different Lucene.net and NHibernater versions.

I did the same pull request to the original branch of Mateusbello some days ago but I didn't received any response... 

Best regards,
Emanuele